### PR TITLE
fix: harden NetWitness July connector intake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.7
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publisher: Splunk <br>
 Connector Version: 2.0.13 <br>
 Product Vendor: RSA <br>
 Product Name: NetWitness Endpoint <br>
-Minimum Product Version: 5.1.0
+Minimum Product Version: 6.3.0
 
 This app supports executing various endpoint-based investigative and containment actions on RSA NetWitness Endpoint
 

--- a/netwitnessendpoint.json
+++ b/netwitnessendpoint.json
@@ -13,7 +13,7 @@
     "product_name": "NetWitness Endpoint",
     "product_version_regex": ".*",
     "python_version": "3.9, 3.13",
-    "min_phantom_version": "5.1.0",
+    "min_phantom_version": "6.3.0",
     "fips_compliant": true,
     "latest_tested_versions": [
         "RSA NetWitness Endpoint, Ver - 4.3.0.1"

--- a/netwitnessendpoint_connector.py
+++ b/netwitnessendpoint_connector.py
@@ -18,9 +18,11 @@
 import hashlib
 import ipaddress
 import json
+import unicodedata
 from urllib.parse import quote
 
 # Phantom imports
+import idna
 import phantom.app as phantom
 import requests
 from dateutil.parser import parse
@@ -146,6 +148,12 @@ class NetwitnessendpointConnector(BaseConnector):
                 return None
 
         return parameter
+
+    @staticmethod
+    def _strip_format_controls(value):
+        if isinstance(value, str):
+            return "".join(character for character in value if unicodedata.category(character) != "Cf")
+        return value
 
     def _make_rest_call(self, endpoint, action_result, params=None, data=None, method="post", timeout=None):
         """Function that makes the REST call to the device. It is a generic function that can be called from various
@@ -274,8 +282,6 @@ class NetwitnessendpointConnector(BaseConnector):
         # Variable that will be used to fetch specific amount of information from the response
         pending_data_length = limit
         max_pages = consts.NWENDPOINT_DEFAULT_MAX_PAGES
-        if limit_provided:
-            max_pages = min(max_pages, max(1, (limit + consts.NWENDPOINT_DEFAULT_LIMIT - 1) // consts.NWENDPOINT_DEFAULT_LIMIT))
 
         for page_count in range(1, max_pages + 1):
             # Making the call
@@ -285,15 +291,16 @@ class NetwitnessendpointConnector(BaseConnector):
             if phantom.is_fail(response_status):
                 return action_result.get_status(), None
 
-            if response[consts.NWENDPOINT_REST_RESPONSE].get(key):
-                return_list += response[consts.NWENDPOINT_REST_RESPONSE][key][:pending_data_length]
+            page_data = response[consts.NWENDPOINT_REST_RESPONSE].get(key, [])
+            received_data_length = len(page_data)
+            return_list += page_data[:pending_data_length]
 
             if limit_provided:
                 if len(return_list) >= limit:
                     break
 
                 # next expected amount of information to fetch from the response
-                pending_data_length -= consts.NWENDPOINT_DEFAULT_LIMIT
+                pending_data_length -= received_data_length
 
             params["page"] += 1
 
@@ -415,8 +422,12 @@ class NetwitnessendpointConnector(BaseConnector):
         domain = param[consts.NWENDPOINT_JSON_DOMAIN]
 
         # Convert URL to domain
-        if phantom.is_url(domain):
-            domain = phantom.get_host_from_url(domain)
+        try:
+            if phantom.is_url(domain):
+                domain = phantom.get_host_from_url(domain)
+            domain = idna.encode(domain, uts46=True).decode("ascii")
+        except (ValueError, idna.IDNAError):
+            return action_result.set_status(phantom.APP_ERROR, "Provide a valid domain or URL")
 
         # Get mandatory parameter
         payload = {"Domains": [domain]}
@@ -917,16 +928,18 @@ class NetwitnessendpointConnector(BaseConnector):
             )
             source_data_identifiers = []
             # Creating container
+            ioc_name = self._strip_format_controls(ioc["Name"])
+            ioc_type = self._strip_format_controls(ioc["Type"])
             container = {
-                "name": "{}-{}".format(ioc["Name"], ioc["Type"]),
-                "description": ioc["Description"],
+                "name": f"{ioc_name}-{ioc_type}",
+                "description": self._strip_format_controls(ioc["Description"]),
                 "data": json.dumps(ioc),
-                "source_data_identifier": "{}-{}".format(ioc["Name"], ioc["Type"]),
+                "source_data_identifier": f"{ioc_name}-{ioc_type}",
             }
 
             self.send_progress("Ingesting data for: {}".format(ioc["Name"]))
 
-            ret_value, response, container_id = self.save_container(container)
+            ret_value, _response, container_id = self.save_container(container)
 
             # Something went wrong while creating container
             if phantom.is_fail(ret_value):
@@ -941,7 +954,7 @@ class NetwitnessendpointConnector(BaseConnector):
                 for field, artifact_details in machine_artifacts_mappings.items():
                     # if field value is present
                     if machine.get(field):
-                        cef_value = machine[field]
+                        cef_value = self._strip_format_controls(machine[field])
 
                         cef[artifact_details["cef"]] = cef_value
                         cef_types[artifact_details["cef"]] = artifact_details["cef_types"]
@@ -968,7 +981,7 @@ class NetwitnessendpointConnector(BaseConnector):
 
                 # The source_data_identifier should be created after all the keys have been set
                 artifact["source_data_identifier"] = source_data_identifier
-                ret_value, status_string, artifact_id = self.save_artifact(artifact)
+                ret_value, status_string, _artifact_id = self.save_artifact(artifact)
 
                 # Something went wrong while creating artifacts
                 if phantom.is_fail(ret_value):
@@ -986,7 +999,7 @@ class NetwitnessendpointConnector(BaseConnector):
                     # if field value is present
                     machine_field = machine_module.get(field)
                     if machine_field:
-                        cef_value = machine_field
+                        cef_value = self._strip_format_controls(machine_field)
 
                         cef[artifact_details["cef"]] = cef_value
                         cef_types[artifact_details["cef"]] = artifact_details["cef_types"]
@@ -1013,7 +1026,7 @@ class NetwitnessendpointConnector(BaseConnector):
 
                 # The source_data_identifier should be created after all the keys have been set.
                 artifact["source_data_identifier"] = source_data_identifier
-                ret_value, status_string, artifact_id = self.save_artifact(artifact)
+                ret_value, status_string, _artifact_id = self.save_artifact(artifact)
 
                 # Something went wrong while creating artifacts
                 if phantom.is_fail(ret_value):
@@ -1023,11 +1036,16 @@ class NetwitnessendpointConnector(BaseConnector):
                     continue
 
             # Adding IIOC details as artifact
-            cef = {"instantIocName": ioc["Name"], "lastExecutedTime": ioc["LastExecuted"], "iocLevel": ioc["IOCLevel"], "osType": ioc["Type"]}
+            cef = {
+                "instantIocName": ioc_name,
+                "lastExecutedTime": self._strip_format_controls(ioc["LastExecuted"]),
+                "iocLevel": self._strip_format_controls(ioc["IOCLevel"]),
+                "osType": ioc_type,
+            }
 
             # If Module type is found in IOC, then it will be added to the artifact
             if ioc.get("ioc_type"):
-                cef["iocType"] = ioc["ioc_type"]
+                cef["iocType"] = self._strip_format_controls(ioc["ioc_type"])
 
             cef_types = {"instantIocName": ["nwe ioc name"]}
 
@@ -1040,7 +1058,7 @@ class NetwitnessendpointConnector(BaseConnector):
                 "run_automation": True,
             }
             artifact["source_data_identifier"] = self._create_dict_hash(artifact)
-            ret_value, status_string, artifact_id = self.save_artifact(artifact)
+            ret_value, status_string, _artifact_id = self.save_artifact(artifact)
 
             # Something went wrong while creating artifacts
             if phantom.is_fail(ret_value):
@@ -1308,7 +1326,7 @@ class NetwitnessendpointConnector(BaseConnector):
         self.save_progress(f"Configured URL: {self._url}")
 
         # making call
-        ret_value, response = self._make_rest_call(consts.NWENDPOINT_TEST_CONNECTIVITY_ENDPOINT, action_result, method="get", timeout=300)
+        ret_value, _response = self._make_rest_call(consts.NWENDPOINT_TEST_CONNECTIVITY_ENDPOINT, action_result, method="get", timeout=300)
 
         # something went wrong
         if phantom.is_fail(ret_value):

--- a/netwitnessendpoint_display_scan_data.html
+++ b/netwitnessendpoint_display_scan_data.html
@@ -400,337 +400,337 @@ and limitations under the License.
                       </a>
                     </td>
                   </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="Tasks_div">
-            <h3 class="wf-h3-style">Tasks</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="Tasks_div">
+          <h3 class="wf-h3-style">Tasks</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>File Name</th>
+                <th>IIOC Score</th>
+                <th>Risk Score</th>
+                <th>Signature</th>
+                <th>Machine Count</th>
+                <th>Hash Lookup</th>
+                <th>Trigger</th>
+                <th>Next Run Time</th>
+                <th>Last Run Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data.Tasks %}
                 <tr>
-                  <th>File Name</th>
-                  <th>IIOC Score</th>
-                  <th>Risk Score</th>
-                  <th>Signature</th>
-                  <th>Machine Count</th>
-                  <th>Hash Lookup</th>
-                  <th>Trigger</th>
-                  <th>Next Run Time</th>
-                  <th>Last Run Time</th>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.FileName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.FileName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.IIOCScore }}</td>
+                  <td>{{ item.RiskScore }}</td>
+                  <td>{{ item.Signature }}</td>
+                  <td>{{ item.MachineCount }}</td>
+                  <td>{{ item.HashLookup }}</td>
+                  <td>{{ item.Trigger }}</td>
+                  <td>{{ item.NextRunTime }}</td>
+                  <td>{{ item.LastRunTime }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data.Tasks %}
-                  <tr>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.FileName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.FileName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.IIOCScore }}</td>
-                    <td>{{ item.RiskScore }}</td>
-                    <td>{{ item.Signature }}</td>
-                    <td>{{ item.MachineCount }}</td>
-                    <td>{{ item.HashLookup }}</td>
-                    <td>{{ item.Trigger }}</td>
-                    <td>{{ item.NextRunTime }}</td>
-                    <td>{{ item.LastRunTime }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="ImageHooks_div">
-            <h3 class="wf-h3-style">Image Hooks</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="ImageHooks_div">
+          <h3 class="wf-h3-style">Image Hooks</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>Hooker Module File Name</th>
+                <th>IIOC Score</th>
+                <th>Risk Score</th>
+                <th>Hooked Process</th>
+                <th>Hooked Module File Name</th>
+                <th>Hooked Symbol</th>
+                <th>Machine Count</th>
+                <th>Signature</th>
+                <th>Hash Lookup</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data|by_key:"ImageHooks" %}
                 <tr>
-                  <th>Hooker Module File Name</th>
-                  <th>IIOC Score</th>
-                  <th>Risk Score</th>
-                  <th>Hooked Process</th>
-                  <th>Hooked Module File Name</th>
-                  <th>Hooked Symbol</th>
-                  <th>Machine Count</th>
-                  <th>Signature</th>
-                  <th>Hash Lookup</th>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.HookerModuleFileName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.HookerModuleFileName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.IIOCScore }}</td>
+                  <td>{{ item.RiskScore }}</td>
+                  <td>{{ item.HookedProcess }}</td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.HookedModuleFileName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.HookedModuleFileName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.HookedSymbol }}</td>
+                  <td>{{ item.MachineCount }}</td>
+                  <td>{{ item.Signature }}</td>
+                  <td>{{ item.HashLookup }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data|by_key:"ImageHooks" %}
-                  <tr>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.HookerModuleFileName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.HookerModuleFileName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.IIOCScore }}</td>
-                    <td>{{ item.RiskScore }}</td>
-                    <td>{{ item.HookedProcess }}</td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.HookedModuleFileName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.HookedModuleFileName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.HookedSymbol }}</td>
-                    <td>{{ item.MachineCount }}</td>
-                    <td>{{ item.Signature }}</td>
-                    <td>{{ item.HashLookup }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="KernelHooks_div">
-            <h3 class="wf-h3-style">Kernel Hooks</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="KernelHooks_div">
+          <h3 class="wf-h3-style">Kernel Hooks</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>Hooker Module File Name</th>
+                <th>IIOC Score</th>
+                <th>Risk Score</th>
+                <th>Kernel Hooked Type</th>
+                <th>Object Name</th>
+                <th>Function Name</th>
+                <th>Machine Count</th>
+                <th>Signature</th>
+                <th>Hash Lookup</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data|by_key:"KernelHooks" %}
                 <tr>
-                  <th>Hooker Module File Name</th>
-                  <th>IIOC Score</th>
-                  <th>Risk Score</th>
-                  <th>Kernel Hooked Type</th>
-                  <th>Object Name</th>
-                  <th>Function Name</th>
-                  <th>Machine Count</th>
-                  <th>Signature</th>
-                  <th>Hash Lookup</th>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.HookerModuleFileName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.HookerModuleFileName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.IIOCScore }}</td>
+                  <td>{{ item.RiskScore }}</td>
+                  <td>{{ item.KernelHookType }}</td>
+                  <td>{{ item.ObjectName }}</td>
+                  <td>{{ item.FunctionName }}</td>
+                  <td>{{ item.MachineCount }}</td>
+                  <td>{{ item.Signature }}</td>
+                  <td>{{ item.HashLookup }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data|by_key:"KernelHooks" %}
-                  <tr>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.HookerModuleFileName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.HookerModuleFileName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.IIOCScore }}</td>
-                    <td>{{ item.RiskScore }}</td>
-                    <td>{{ item.KernelHookType }}</td>
-                    <td>{{ item.ObjectName }}</td>
-                    <td>{{ item.FunctionName }}</td>
-                    <td>{{ item.MachineCount }}</td>
-                    <td>{{ item.Signature }}</td>
-                    <td>{{ item.HashLookup }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="WindowsHooks_div">
-            <h3 class="wf-h3-style">Windows Hooks</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="WindowsHooks_div">
+          <h3 class="wf-h3-style">Windows Hooks</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>File Name</th>
+                <th>IIOC Score</th>
+                <th>Risk Score</th>
+                <th>Hooked Process</th>
+                <th>Hooked PID</th>
+                <th>Hooker PID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data|by_key:"WindowsHooks" %}
                 <tr>
-                  <th>File Name</th>
-                  <th>IIOC Score</th>
-                  <th>Risk Score</th>
-                  <th>Hooked Process</th>
-                  <th>Hooked PID</th>
-                  <th>Hooker PID</th>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.FileName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.FileName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.IIOCScore }}</td>
+                  <td>{{ item.RiskScore }}</td>
+                  <td>{{ item.HookedProcess }}</td>
+                  <td>{{ item.HookedPID }}</td>
+                  <td>{{ item.HookerPID }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data|by_key:"WindowsHooks" %}
-                  <tr>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.FileName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.FileName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.IIOCScore }}</td>
-                    <td>{{ item.RiskScore }}</td>
-                    <td>{{ item.HookedProcess }}</td>
-                    <td>{{ item.HookedPID }}</td>
-                    <td>{{ item.HookerPID }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="SuspiciousThreads_div">
-            <h3 class="wf-h3-style">Suspicious Threads</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="SuspiciousThreads_div">
+          <h3 class="wf-h3-style">Suspicious Threads</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>Process Context</th>
+                <th>Module Name</th>
+                <th>IIOC Score</th>
+                <th>Risk Score</th>
+                <th>Machine Count</th>
+                <th>Signature</th>
+                <th>Hash Lookup</th>
+                <th>File Creation Time</th>
+                <th>Full Path</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data|by_key:"SuspiciousThreads" %}
                 <tr>
-                  <th>Process Context</th>
-                  <th>Module Name</th>
-                  <th>IIOC Score</th>
-                  <th>Risk Score</th>
-                  <th>Machine Count</th>
-                  <th>Signature</th>
-                  <th>Hash Lookup</th>
-                  <th>File Creation Time</th>
-                  <th>Full Path</th>
+                  <td>{{ item.ProcessContext }}</td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.ModuleName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.ModuleName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.IIOCScore }}</td>
+                  <td>{{ item.RiskScore }}</td>
+                  <td>{{ item.MachineCount }}</td>
+                  <td>{{ item.Signature }}</td>
+                  <td>{{ item.HashLookup }}</td>
+                  <td>{{ item.FileCreationTime }}</td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ item.FullPath }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.FullPath }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data|by_key:"SuspiciousThreads" %}
-                  <tr>
-                    <td>{{ item.ProcessContext }}</td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.ModuleName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.ModuleName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.IIOCScore }}</td>
-                    <td>{{ item.RiskScore }}</td>
-                    <td>{{ item.MachineCount }}</td>
-                    <td>{{ item.Signature }}</td>
-                    <td>{{ item.HashLookup }}</td>
-                    <td>{{ item.FileCreationTime }}</td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ item.FullPath }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.FullPath }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="RegistryDiscrepancies_div">
-            <h3 class="wf-h3-style">Registry Discrepancies</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="RegistryDiscrepancies_div">
+          <h3 class="wf-h3-style">Registry Discrepancies</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>Hive</th>
+                <th>Path</th>
+                <th>Data</th>
+                <th>Data Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data|by_key:"RegistryDiscrepancies" %}
                 <tr>
-                  <th>Hive</th>
-                  <th>Path</th>
-                  <th>Data</th>
-                  <th>Data Type</th>
+                  <td>{{ item.Hive }}</td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ item.Path }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.Path }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.Data }}</td>
+                  <td>{{ item.DataType }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data|by_key:"RegistryDiscrepancies" %}
-                  <tr>
-                    <td>{{ item.Hive }}</td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ item.Path }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.Path }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.Data }}</td>
-                    <td>{{ item.DataType }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="Network_div">
-            <h3 class="wf-h3-style">Network</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="Network_div">
+          <h3 class="wf-h3-style">Network</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>Process</th>
+                <th>Module</th>
+                <th>IP</th>
+                <th>Domain</th>
+                <th>Port</th>
+                <th>Listen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data.Network %}
                 <tr>
-                  <th>Process</th>
-                  <th>Module</th>
-                  <th>IP</th>
-                  <th>Domain</th>
-                  <th>Port</th>
-                  <th>Listen</th>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ item.Process }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.Process }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.ModuleName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.ModuleName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ item.IP }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.IP }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': [' domain '], 'value': '{{ item.Domain }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.Domain }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.Port }}</td>
+                  <td>{{ item.Listen }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data.Network %}
-                  <tr>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['process name'], 'value': '{{ item.Process }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.Process }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.ModuleName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.ModuleName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ item.IP }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.IP }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': [' domain '], 'value': '{{ item.Domain }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.Domain }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.Port }}</td>
-                    <td>{{ item.Listen }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-          <div class="show_detail" id="Tracking_div">
-            <h3 class="wf-h3-style">Tracking</h3>
-            <table class="wf-table-horizontal datatable">
-              <thead>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="show_detail" id="Tracking_div">
+          <h3 class="wf-h3-style">Tracking</h3>
+          <table class="wf-table-horizontal datatable">
+            <thead>
+              <tr>
+                <th>Source File Name</th>
+                <th>Event</th>
+                <th>Target</th>
+                <th>IIOC Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in result.data.Tracking %}
                 <tr>
-                  <th>Source File Name</th>
-                  <th>Event</th>
-                  <th>Target</th>
-                  <th>IIOC Score</th>
+                  <td>
+                    <a href="javascript:;"
+                       onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.SourceFileName }}' }], 0, {{ container.id }}, null, false);">
+                      {{ item.SourceFileName }}
+                      &nbsp;
+                      <span class="fa fa-caret-down" style="font-size: smaller;"></span>
+                    </a>
+                  </td>
+                  <td>{{ item.Event }}</td>
+                  <td>{{ item.Target }}</td>
+                  <td>{{ item.IIOCScore }}</td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for item in result.data.Tracking %}
-                  <tr>
-                    <td>
-                      <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': ['file name'], 'value': '{{ item.SourceFileName }}' }], 0, {{ container.id }}, null, false);">
-                        {{ item.SourceFileName }}
-                        &nbsp;
-                        <span class="fa fa-caret-down" style="font-size: smaller;"></span>
-                      </a>
-                    </td>
-                    <td>{{ item.Event }}</td>
-                    <td>{{ item.Target }}</td>
-                    <td>{{ item.IIOCScore }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        {% endif %}
-      {% endfor %}
-    </div>
-    <script>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <script>
 $.extend(true, $.fn.dataTable.defaults, {
     "searching": true,
     "bLengthChange": false,
@@ -754,5 +754,5 @@ $.extend(true, $.fn.dataTable.defaults, {
     $('.show_detail').hide();
     $('#'+id+'_div').show();
   }
-    </script>
-  {% endblock %}
+  </script>
+{% endblock %}

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,5 @@
 **Unreleased**
 
-* Chore: Refresh connector validation hooks.
+* Fix domain blocklisting for malformed URLs and internationalized domain names.
+* Preserve every requested API result from short response pages.
+* Remove invisible Unicode format controls from ingested IOC data.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Fix domain blocklisting for malformed URLs and internationalized domain names.
 * Preserve every requested API result from short response pages.
 * Remove invisible Unicode format controls from ingested IOC data.
+* Require Splunk SOAR 6.3.0 or later.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: Refresh connector validation hooks.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,4 +3,3 @@
 * Fix domain blocklisting for malformed URLs and internationalized domain names.
 * Preserve every requested API result from short response pages.
 * Remove invisible Unicode format controls from ingested IOC data.
-* Require Splunk SOAR 6.3.0 or later.


### PR DESCRIPTION
## Summary

- handle malformed URLs and normalize IDNs before domain blocklisting
- preserve requested records from short paginated responses
- remove Unicode format controls from ingested IOC display fields
- require Splunk SOAR 6.3.0 or later

## Tracking

- Epic: ESPM-5228
- PAPP: PAPP-38279
- PSAAS: PSAAS-32837, PSAAS-32850, PSAAS-33231, PSAAS-33514
- Duplicate closed separately: PSAAS-32936 (merged PR #21)
- Platform-routed locally without Jira mutation: PSAAS-33460

## Validation

- full pre-commit suite passed with dev-cicd-tools v2.2.8 under Python 3.13/public PyPI
- Python compilation passed
- all commits are signed

This pull request and its changes were written by Codex.